### PR TITLE
add missing APP_NAME parameter, where cartridge is added

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Note: this cartridge does NOT run in an Auto-Scale app configuration.
 
 To install it run this command:
 
-    rhc cartridge add http://cartreflect-claytondev.rhcloud.com/github/liberapay/openshift-cartridge-postgres
+    rhc cartridge add -a APP_NAME http://cartreflect-claytondev.rhcloud.com/github/liberapay/openshift-cartridge-postgres
 
 Don't forget to make regular backups of your databases using `pg_dump`, and be
 careful not to delete or alter the `$OPENSHIFT_DATA_DIR/postgres/` directory


### PR DESCRIPTION
as I understand there must be an APP_NAME if you add a database cartridge, right?
